### PR TITLE
Add API key query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ or, if you prefer to build from source:
 `pelias-js` expects a configuration object at time of instantiation, with the format:
 ```
   {
-    peliasUrl: string
+    peliasUrl: string,
+    apiKey: string /* optional */
   }
 ```
 
-where peliasUrl is a string containing the URL, with protocol and port, to your Pelias instance.
+where peliasUrl is a string containing the URL, with protocol and port, to your Pelias instance. If you are using a hosted Pelias-compatible service such as [geocode.earth](https://geocode.earth/) you will also need to provide an API key.
 
 ## Example Usage
 ```

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,6 +17,7 @@ export const SEARCH_ENDPOINT = "/v1/search?"
 
 // Query string params
 export const QS_TEXT = "text"
+export const QS_API_KEY = "api_key"
 export const QS_FOCUS_LAT = "focus.point.lat"
 export const QS_FOCUS_LONG = "focus.point.lon"
 export const QS_RESULTS_LIMIT = "size"

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -13,7 +13,8 @@ import {
 } from "../util/validate/validate";
 
 interface ISearchObject {
-  searchTerm: string
+  searchTerm: string,
+  apiKey: string,
   focusPoint?: ICoordinate
   resultsLimit?: string
   boundaryCountry?: string
@@ -43,7 +44,8 @@ interface ICoordinate {
 }
 
 interface IConfig {
-  peliasUrl: string
+  peliasUrl: string,
+  apiKey: string
 }
 
 // Auto-instantiate in case caller forgets 'new' so as not to pollute the global namespace
@@ -57,7 +59,8 @@ class Search {
 
   constructor(config: IConfig) {
     this._searchObject = {
-      searchTerm: undefined
+      searchTerm: undefined,
+      apiKey: config.apiKey || undefined
     }
     if(!('peliasUrl' in config)) {
       throw new Error("peliasUrl must be specified in the constructor")
@@ -160,6 +163,10 @@ const buildSearchQueryString = (searchObject: ISearchObject) => {
 
   if(searchObject.searchTerm) {
     paramsArray.push([Constants.QS_TEXT, searchObject.searchTerm] )
+  }
+
+  if(searchObject.apiKey) {
+    paramsArray.push([Constants.QS_API_KEY, searchObject.apiKey])
   }
 
   if(searchObject.focusPoint) {

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -45,7 +45,7 @@ interface ICoordinate {
 
 interface IConfig {
   peliasUrl: string,
-  apiKey: string
+  apiKey?: string
 }
 
 // Auto-instantiate in case caller forgets 'new' so as not to pollute the global namespace


### PR DESCRIPTION
This allows instantiating the `Pelias` object with an optional `apiKey` property, which is used by the commercial hosted Pelias services like [geocode.earth](https://geocode.earth/). Although it's not an official part of the Pelias API spec, it'll be necessary to use this library with a third-party hosted service.